### PR TITLE
Use hyper v1

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+Cargo.lock binary

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -576,15 +576,15 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.9.0"
+version = "3.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01ce4141aa927a6d1bd34a041795abd0db1cccba5d5f24b009f694bdf3a1f3fa"
+checksum = "7ef1adac450ad7f4b3c28589471ade84f25f731a7a0fe30d71dfa9f60fd808e5"
 dependencies = [
  "cfg-if",
  "fastrand",
  "redox_syscall",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -22,8 +22,8 @@ name = "arnold"
 version = "0.2.0"
 dependencies = [
  "bytes",
- "http 1.0.0",
- "http-body 1.0.0",
+ "http",
+ "http-body",
  "http-body-util",
  "pin-project",
  "static_assertions",
@@ -75,8 +75,9 @@ dependencies = [
  "camino",
  "futures-core",
  "futures-util",
- "http 1.0.0",
+ "http",
  "hyper",
+ "hyper-util",
  "pem-rfc7468",
  "pin-project",
  "rustls",
@@ -214,16 +215,16 @@ checksum = "4271d37baee1b8c7e4b708028c57d816cf9d2434acb33a549475f78c181f6253"
 
 [[package]]
 name = "h2"
-version = "0.3.22"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d6250322ef6e60f93f9a2162799302cd6f68f79f6e5d85c8c16f14d1d958178"
+checksum = "e1d308f63daf4181410c242d34c11f928dcb3aa105852019e043c9d1f4e4368a"
 dependencies = [
  "bytes",
  "fnv",
  "futures-core",
  "futures-sink",
  "futures-util",
- "http 0.2.11",
+ "http",
  "indexmap",
  "slab",
  "tokio",
@@ -239,17 +240,6 @@ checksum = "290f1a1d9242c78d09ce40a5e87e7554ee637af1351968159f4952f028f75604"
 
 [[package]]
 name = "http"
-version = "0.2.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8947b1a6fad4393052c7ba1f4cd97bed3e953a95c79c92ad9b051a04611d9fbb"
-dependencies = [
- "bytes",
- "fnv",
- "itoa",
-]
-
-[[package]]
-name = "http"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b32afd38673a8016f7c9ae69e5af41a58f81b1d31689040f2f1959594ce194ea"
@@ -261,23 +251,12 @@ dependencies = [
 
 [[package]]
 name = "http-body"
-version = "0.4.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ceab25649e9960c0311ea418d17bee82c0dcec1bd053b5f9a66e265a693bed2"
-dependencies = [
- "bytes",
- "http 0.2.11",
- "pin-project-lite",
-]
-
-[[package]]
-name = "http-body"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1cac85db508abc24a2e48553ba12a996e87244a0395ce011e62b37158745d643"
 dependencies = [
  "bytes",
- "http 1.0.0",
+ "http",
 ]
 
 [[package]]
@@ -288,8 +267,8 @@ checksum = "41cb79eb393015dadd30fc252023adb0b2400a0caee0fa2a077e6e21a551e840"
 dependencies = [
  "bytes",
  "futures-util",
- "http 1.0.0",
- "http-body 1.0.0",
+ "http",
+ "http-body",
  "pin-project-lite",
 ]
 
@@ -307,26 +286,42 @@ checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
 name = "hyper"
-version = "0.14.28"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf96e135eb83a2a8ddf766e426a841d8ddd7449d5f00d34ea02b41d2f19eef80"
+checksum = "fb5aa53871fc917b1a9ed87b683a5d86db645e23acb32c2e0785a353e522fb75"
 dependencies = [
  "bytes",
  "futures-channel",
- "futures-core",
  "futures-util",
  "h2",
- "http 0.2.11",
- "http-body 0.4.6",
+ "http",
+ "http-body",
  "httparse",
  "httpdate",
  "itoa",
  "pin-project-lite",
+ "tokio",
+ "want",
+]
+
+[[package]]
+name = "hyper-util"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bdea9aac0dbe5a9240d68cfd9501e2db94222c6dc06843e06640b9e07f0fdc67"
+dependencies = [
+ "bytes",
+ "futures-channel",
+ "futures-util",
+ "http",
+ "http-body",
+ "hyper",
+ "pin-project-lite",
  "socket2",
  "tokio",
+ "tower",
  "tower-service",
  "tracing",
- "want",
 ]
 
 [[package]]
@@ -669,6 +664,11 @@ version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8fa9be0de6cf49e536ce1851f987bd21a43b771b09473c3549a6c853db37c1c"
 dependencies = [
+ "futures-core",
+ "futures-util",
+ "pin-project",
+ "pin-project-lite",
+ "tokio",
  "tower-layer",
  "tower-service",
  "tracing",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,8 @@ futures-util = "0.3"
 http = { version = "1" }
 http-body = { version = "1" }
 http-body-util = { version = "0.1" }
-hyper = { version = "<1" }
+hyper = { version = "1", features = ["full"] }
+hyper-util = { version = "0.1", features = ["client"] }
 pin-project = { version = "1" }
 rustls = "^0.21"
 static-assertions = { version = "1", package = "static_assertions" }

--- a/braid/Cargo.toml
+++ b/braid/Cargo.toml
@@ -18,6 +18,10 @@ tokio-rustls.workspace = true
 tower.workspace = true
 tracing.workspace = true
 
+[dependencies.hyper-util]
+workspace = true
+features = ["client", "client-legacy", "tokio"]
+
 [dev-dependencies]
 futures-util.workspace = true
 pem-rfc7468 = { version = "0.7", features = ["alloc"] }

--- a/braid/src/client.rs
+++ b/braid/src/client.rs
@@ -3,6 +3,8 @@
 //! The server and client are differentiated for TLS support, but otherwise,
 //! TCP and Duplex streams are the same whether they are server or client.
 
+use std::net::SocketAddr;
+
 use pin_project::pin_project;
 use tokio::io::{AsyncRead, AsyncWrite};
 use tokio::net::{TcpStream, UnixStream};
@@ -17,6 +19,13 @@ use crate::tls::client::TlsStream;
 pub struct Stream {
     #[pin]
     inner: Braid<TlsStream>,
+}
+
+impl Stream {
+    pub async fn connect(addr: impl Into<SocketAddr>) -> std::io::Result<Self> {
+        let stream = TcpStream::connect(addr.into()).await?;
+        Ok(stream.into())
+    }
 }
 
 impl From<TcpStream> for Stream {

--- a/braid/src/server/acceptor.rs
+++ b/braid/src/server/acceptor.rs
@@ -11,7 +11,7 @@ use tokio::net::{TcpListener, UnixListener};
 use super::Accept;
 use super::Stream;
 use crate::duplex::DuplexIncoming;
-use crate::tls::server::acceptor::TlsAcceptor;
+use crate::tls::server::TlsAcceptor;
 
 /// A stream of incoming connections.
 ///

--- a/braid/src/tls/server/acceptor.rs
+++ b/braid/src/tls/server/acceptor.rs
@@ -28,7 +28,7 @@ use crate::server::Accept;
 pub(super) use super::TlsStream;
 
 impl TlsAcceptor {
-    /// Create a new TLS Acceptor with the given [rustls::ServerConfig] and [hyper::server::conn::AddrIncoming].
+    /// Create a new TLS Acceptor with the given [rustls::ServerConfig] and [tokio::net:TcpListener].
     pub fn new(config: Arc<ServerConfig>, incoming: TcpListener) -> TlsAcceptor {
         TlsAcceptor { config, incoming }
     }

--- a/braid/src/tls/server/acceptor.rs
+++ b/braid/src/tls/server/acceptor.rs
@@ -5,10 +5,9 @@ use std::pin::Pin;
 use std::{io, sync::Arc};
 
 use futures_core::ready;
-use hyper::server::accept::Accept;
-use hyper::server::conn::AddrIncoming;
 use pin_project::pin_project;
 use rustls::ServerConfig;
+use tokio::net::TcpListener;
 
 /// TLS Acceptor which uses a [rustls::ServerConfig] to accept connections
 /// and start a TLS handshake.
@@ -21,14 +20,16 @@ use rustls::ServerConfig;
 pub struct TlsAcceptor {
     config: Arc<ServerConfig>,
     #[pin]
-    incoming: AddrIncoming,
+    incoming: TcpListener,
 }
+
+use crate::server::Accept;
 
 pub(super) use super::TlsStream;
 
 impl TlsAcceptor {
     /// Create a new TLS Acceptor with the given [rustls::ServerConfig] and [hyper::server::conn::AddrIncoming].
-    pub fn new(config: Arc<ServerConfig>, incoming: AddrIncoming) -> TlsAcceptor {
+    pub fn new(config: Arc<ServerConfig>, incoming: TcpListener) -> TlsAcceptor {
         TlsAcceptor { config, incoming }
     }
 }
@@ -40,22 +41,19 @@ impl Accept for TlsAcceptor {
     fn poll_accept(
         self: Pin<&mut Self>,
         cx: &mut Context<'_>,
-    ) -> Poll<Option<Result<Self::Conn, Self::Error>>> {
+    ) -> Poll<Result<Self::Conn, Self::Error>> {
         let this = self.project();
 
         match ready!(this.incoming.poll_accept(cx)) {
             // A new TCP connection is ready to be accepted.
-            Some(Ok(stream)) => {
+            Ok((stream, remote_addr)) => {
                 let accept =
                     tokio_rustls::TlsAcceptor::from(Arc::clone(this.config)).accept(stream);
-                Poll::Ready(Some(Ok(accept.into())))
+                Poll::Ready(Ok(TlsStream::new(accept, remote_addr.into())))
             }
 
             // An error occurred while accepting a new TCP connection.
-            Some(Err(e)) => Poll::Ready(Some(Err(e))),
-
-            // No new TCP connection is ready to be accepted.
-            None => Poll::Ready(None),
+            Err(e) => Poll::Ready(Err(e)),
         }
     }
 }

--- a/braid/src/tls/server/acceptor.rs
+++ b/braid/src/tls/server/acceptor.rs
@@ -28,7 +28,7 @@ use crate::server::Accept;
 pub(super) use super::TlsStream;
 
 impl TlsAcceptor {
-    /// Create a new TLS Acceptor with the given [rustls::ServerConfig] and [tokio::net:TcpListener].
+    /// Create a new TLS Acceptor with the given [rustls::ServerConfig] and [tokio::net::TcpListener].
     pub fn new(config: Arc<ServerConfig>, incoming: TcpListener) -> TlsAcceptor {
         TlsAcceptor { config, incoming }
     }

--- a/braid/src/tls/server/mod.rs
+++ b/braid/src/tls/server/mod.rs
@@ -21,6 +21,8 @@ pub(crate) mod info;
 pub mod sni;
 
 pub use self::acceptor::TlsAcceptor;
+pub use self::connector::TlsConnectLayer;
+
 /// State tracks the process of accepting a connection and turning it into a stream.
 enum TlsState {
     Handshake(tokio_rustls::Accept<TcpStream>),

--- a/braid/src/tls/server/mod.rs
+++ b/braid/src/tls/server/mod.rs
@@ -8,11 +8,11 @@ use std::{fmt, io};
 use std::{future::Future, pin::Pin};
 
 use futures_core::ready;
-use hyper::server::conn::AddrStream;
 use tokio::io::{AsyncRead, AsyncWrite, ReadBuf};
+use tokio::net::TcpStream;
 use tokio_rustls::Accept;
 
-use crate::info::{ConnectionInfo, SocketAddr};
+use crate::info::{ConnectionInfo, SocketAddr, TLSConnectionInfo};
 
 pub mod acceptor;
 pub mod connector;
@@ -23,25 +23,15 @@ pub mod sni;
 pub use self::acceptor::TlsAcceptor;
 /// State tracks the process of accepting a connection and turning it into a stream.
 enum TlsState {
-    Handshake(tokio_rustls::Accept<AddrStream>),
-    Streaming(tokio_rustls::server::TlsStream<AddrStream>),
+    Handshake(tokio_rustls::Accept<TcpStream>),
+    Streaming(tokio_rustls::server::TlsStream<TcpStream>),
 }
 
 impl fmt::Debug for TlsState {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            TlsState::Handshake(accept) => {
-                let remote = accept.get_ref().map(|stream| stream.remote_addr());
-                if let Some(remote) = remote {
-                    write!(f, "State::Handshake({remote:?})")
-                } else {
-                    f.write_str("State::Handshake")
-                }
-            }
-            TlsState::Streaming(stream) => {
-                let remote = stream.get_ref().0.remote_addr();
-                write!(f, "State::Streaming({remote:?})")
-            }
+            TlsState::Handshake(_) => f.write_str("State::Handshake"),
+            TlsState::Streaming(_) => f.write_str("State::Streaming"),
         }
     }
 }
@@ -100,7 +90,7 @@ impl TlsStream {
     fn handshake<F, R>(&mut self, cx: &mut Context, action: F) -> Poll<io::Result<R>>
     where
         F: FnOnce(
-            &mut tokio_rustls::server::TlsStream<AddrStream>,
+            &mut tokio_rustls::server::TlsStream<TcpStream>,
             &mut Context,
         ) -> Poll<io::Result<R>>,
     {
@@ -109,7 +99,10 @@ impl TlsStream {
                 Ok(mut stream) => {
                     // Take some action here when the handshake happens
 
-                    let info = crate::info::ConnectionInfo::from(&stream);
+                    let info = crate::info::ConnectionInfo::Tcp(TLSConnectionInfo::from_stream(
+                        &stream,
+                        self.rx.remote_addr().clone(),
+                    ));
                     self.info.send(info.clone());
 
                     match &info {
@@ -131,8 +124,8 @@ impl TlsStream {
     }
 }
 
-impl From<Accept<AddrStream>> for TlsStream {
-    fn from(accept: Accept<AddrStream>) -> Self {
+impl TlsStream {
+    fn new(accept: Accept<TcpStream>, remote_addr: SocketAddr) -> Self {
         let (tx, rx) = tokio::sync::oneshot::channel();
 
         // We don't expect these to panic because we assume that the handshake has not finished when
@@ -140,17 +133,14 @@ impl From<Accept<AddrStream>> for TlsStream {
         // does this after the future has returned ready, we should be okay.
         let local_addr = accept
             .get_ref()
-            .map(|stream| stream.local_addr().into())
-            .expect("TLS handshake is not yet completed");
-        let remote_addr = accept
-            .get_ref()
-            .map(|stream| stream.remote_addr().into())
-            .expect("TLS handshake is not yet completed");
+            .and_then(|stream| stream.local_addr().ok())
+            .expect("TLS handshake is not yet completed")
+            .into();
 
         Self {
             state: TlsState::Handshake(accept),
             info: ConnectionInfoState::new(tx),
-            rx: self::info::TlsConnectionInfoReciever::new(rx, local_addr, remote_addr),
+            rx: self::info::TlsConnectionInfoReciever::new(rx, remote_addr, local_addr),
         }
     }
 }

--- a/braid/tests/tcp.rs
+++ b/braid/tests/tcp.rs
@@ -5,9 +5,10 @@ async fn braided_tcp() {
     use futures_util::StreamExt;
     use tokio::io::{AsyncReadExt, AsyncWriteExt};
 
-    let incoming =
-        hyper::server::conn::AddrIncoming::bind(&(Ipv4Addr::LOCALHOST, 0).into()).unwrap();
-    let addr = incoming.local_addr();
+    let incoming = tokio::net::TcpListener::bind((Ipv4Addr::LOCALHOST, 0))
+        .await
+        .unwrap();
+    let addr = incoming.local_addr().unwrap();
 
     let server = braid::server::acceptor::Acceptor::from(incoming);
     tokio::spawn(async move {

--- a/braid/tests/tcp.rs
+++ b/braid/tests/tcp.rs
@@ -20,7 +20,7 @@ async fn braided_tcp() {
         }
     });
 
-    let mut conn = braid::client::Stream::from(tokio::net::TcpStream::connect(addr).await.unwrap());
+    let mut conn = braid::client::Stream::connect(addr).await.unwrap();
 
     let mut buf = [0u8; 1024];
     conn.write_all(b"hello world").await.unwrap();

--- a/braid/tests/tls.rs
+++ b/braid/tests/tls.rs
@@ -47,16 +47,13 @@ async fn braided_tls() {
         }
     });
 
-    let tcp = tokio::net::TcpStream::connect(addr).await.unwrap();
-
-    let client_config = rustls::ClientConfig::builder()
-        .with_safe_defaults()
-        .with_root_certificates(tls_root_store())
-        .with_no_client_auth();
-    let connetor = tokio_rustls::TlsConnector::from(Arc::new(client_config));
-    let tls = braid::tls::client::TlsStream::from(
-        connetor.connect("example.com".try_into().unwrap(), tcp),
-    );
+    let tls = braid::tls::client::TlsStream::connect(
+        addr,
+        "example.com".try_into().unwrap(),
+        tls_root_store(),
+    )
+    .await
+    .unwrap();
 
     let mut conn = braid::client::Stream::from(tls);
 

--- a/braid/tests/tls.rs
+++ b/braid/tests/tls.rs
@@ -28,9 +28,10 @@ async fn braided_tls() {
     use futures_util::StreamExt;
     use tokio::io::{AsyncReadExt, AsyncWriteExt};
 
-    let incoming =
-        hyper::server::conn::AddrIncoming::bind(&(Ipv4Addr::LOCALHOST, 0).into()).unwrap();
-    let addr = incoming.local_addr();
+    let incoming = tokio::net::TcpListener::bind((Ipv4Addr::LOCALHOST, 0))
+        .await
+        .unwrap();
+    let addr = incoming.local_addr().unwrap();
 
     let server = braid::server::acceptor::Acceptor::from(braid::tls::server::TlsAcceptor::new(
         Arc::new(tls_config()),


### PR DESCRIPTION
Primarily refactors braid to use hyper-v1 types. Minimizes reliance on hyper-utils and instead builds features into braid where possible.

