### PR TITLE
Refactor TLS support so it is generic over underlying IO

### DIFF
--- a/braid/src/core.rs
+++ b/braid/src/core.rs
@@ -5,6 +5,7 @@ use tokio::io::{AsyncRead, AsyncWrite};
 use tokio::net::{TcpStream, UnixStream};
 
 use crate::duplex::DuplexStream;
+use crate::info::{Connection, ConnectionInfo};
 
 /// Dispatching wrapper for potential stream connection types
 ///
@@ -14,21 +15,99 @@ use crate::duplex::DuplexStream;
 /// This core type is used in the server and client modules, and so is
 /// generic over the TLS stream type (which is different for client and server).
 #[derive(Debug)]
-#[pin_project(project = BraidProjection)]
-pub(crate) enum Braid<Tls> {
+#[pin_project(project = BraidCoreProjection)]
+pub(crate) enum BraidCore {
     Tcp(#[pin] TcpStream),
     Duplex(#[pin] DuplexStream),
-    Tls(#[pin] Tls),
     Unix(#[pin] UnixStream),
+}
+
+impl Connection for BraidCore {
+    fn info(&self) -> ConnectionInfo {
+        match self {
+            BraidCore::Tcp(stream) => stream.info(),
+            BraidCore::Duplex(stream) => <DuplexStream as Connection>::info(stream),
+            BraidCore::Unix(stream) => stream.info(),
+        }
+    }
+}
+
+macro_rules! dispatch_core {
+    ($driver:ident.$method:ident($($args:expr),+)) => {
+
+        match $driver.project() {
+            BraidCoreProjection::Tcp(stream) => stream.$method($($args),+),
+            BraidCoreProjection::Duplex(stream) => stream.$method($($args),+),
+            BraidCoreProjection::Unix(stream) => stream.$method($($args),+),
+        }
+    };
+}
+
+impl AsyncRead for BraidCore {
+    fn poll_read(
+        self: std::pin::Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+        buf: &mut tokio::io::ReadBuf<'_>,
+    ) -> std::task::Poll<std::io::Result<()>> {
+        dispatch_core!(self.poll_read(cx, buf))
+    }
+}
+
+impl AsyncWrite for BraidCore {
+    fn poll_write(
+        self: std::pin::Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+        buf: &[u8],
+    ) -> std::task::Poll<Result<usize, std::io::Error>> {
+        dispatch_core!(self.poll_write(cx, buf))
+    }
+
+    fn poll_flush(
+        self: std::pin::Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+    ) -> std::task::Poll<Result<(), std::io::Error>> {
+        dispatch_core!(self.poll_flush(cx))
+    }
+
+    fn poll_shutdown(
+        self: std::pin::Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+    ) -> std::task::Poll<Result<(), std::io::Error>> {
+        dispatch_core!(self.poll_shutdown(cx))
+    }
+}
+
+impl From<TcpStream> for BraidCore {
+    fn from(stream: TcpStream) -> Self {
+        Self::Tcp(stream)
+    }
+}
+
+impl From<DuplexStream> for BraidCore {
+    fn from(stream: DuplexStream) -> Self {
+        Self::Duplex(stream)
+    }
+}
+
+impl From<UnixStream> for BraidCore {
+    fn from(stream: UnixStream) -> Self {
+        Self::Unix(stream)
+    }
+}
+
+#[derive(Debug)]
+#[pin_project(project=BraidProjection)]
+pub(crate) enum Braid<Tls> {
+    NoTls(#[pin] BraidCore),
+    Tls(#[pin] Tls),
 }
 
 macro_rules! dispatch {
     ($driver:ident.$method:ident($($args:expr),+)) => {
+
         match $driver.project() {
-            BraidProjection::Tcp(stream) => stream.$method($($args),+),
-            BraidProjection::Duplex(stream) => stream.$method($($args),+),
+            BraidProjection::NoTls(stream) => stream.$method($($args),+),
             BraidProjection::Tls(stream) => stream.$method($($args),+),
-            BraidProjection::Unix(stream) => stream.$method($($args),+),
         }
     };
 }
@@ -70,5 +149,14 @@ where
         cx: &mut std::task::Context<'_>,
     ) -> std::task::Poll<Result<(), std::io::Error>> {
         dispatch!(self.poll_shutdown(cx))
+    }
+}
+
+impl<T, Tls> From<T> for Braid<Tls>
+where
+    T: Into<BraidCore>,
+{
+    fn from(stream: T) -> Self {
+        Self::NoTls(stream.into())
     }
 }

--- a/braid/src/tls/server/connector.rs
+++ b/braid/src/tls/server/connector.rs
@@ -37,7 +37,7 @@ impl<S> TlsConnectionInfoService<S> {
     }
 }
 
-impl<S> Service<&TlsStream> for TlsConnectionInfoService<S>
+impl<S, IO> Service<&TlsStream<IO>> for TlsConnectionInfoService<S>
 where
     S: Clone + Send + 'static,
 {
@@ -54,7 +54,7 @@ where
         Poll::Ready(Ok(()))
     }
 
-    fn call(&mut self, stream: &TlsStream) -> Self::Future {
+    fn call(&mut self, stream: &TlsStream<IO>) -> Self::Future {
         let inner = self.inner.clone();
         let rx = stream.rx.clone();
         ready(Ok(TlsConnection { inner, rx }))

--- a/braid/src/tls/server/mod.rs
+++ b/braid/src/tls/server/mod.rs
@@ -9,10 +9,9 @@ use std::{future::Future, pin::Pin};
 
 use futures_core::ready;
 use tokio::io::{AsyncRead, AsyncWrite, ReadBuf};
-use tokio::net::TcpStream;
 use tokio_rustls::Accept;
 
-use crate::info::{ConnectionInfo, SocketAddr, TLSConnectionInfo};
+use crate::info::{Connection, ConnectionInfo, TLSConnectionInfo};
 
 pub mod acceptor;
 pub mod connector;
@@ -24,12 +23,12 @@ pub use self::acceptor::TlsAcceptor;
 pub use self::connector::TlsConnectLayer;
 
 /// State tracks the process of accepting a connection and turning it into a stream.
-enum TlsState {
-    Handshake(tokio_rustls::Accept<TcpStream>),
-    Streaming(tokio_rustls::server::TlsStream<TcpStream>),
+enum TlsState<IO> {
+    Handshake(tokio_rustls::Accept<IO>),
+    Streaming(tokio_rustls::server::TlsStream<IO>),
 }
 
-impl fmt::Debug for TlsState {
+impl<IO> fmt::Debug for TlsState<IO> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             TlsState::Handshake(_) => f.write_str("State::Handshake"),
@@ -40,80 +39,62 @@ impl fmt::Debug for TlsState {
 
 #[derive(Debug)]
 enum ConnectionInfoState {
-    Pending(tokio::sync::oneshot::Sender<ConnectionInfo>),
-    Received(ConnectionInfo),
+    Pending(tokio::sync::oneshot::Sender<TLSConnectionInfo>),
+    Received,
 }
 
 impl ConnectionInfoState {
-    fn new(tx: tokio::sync::oneshot::Sender<ConnectionInfo>) -> Self {
+    fn new(tx: tokio::sync::oneshot::Sender<TLSConnectionInfo>) -> Self {
         Self::Pending(tx)
     }
 
-    fn send(&mut self, info: ConnectionInfo) {
-        if matches!(self, ConnectionInfoState::Received(_)) {
+    fn send(&mut self, info: TLSConnectionInfo) {
+        if matches!(self, ConnectionInfoState::Received) {
             panic!("ConnectionInfo already sent");
         }
 
-        let sender = std::mem::replace(self, ConnectionInfoState::Received(info.clone()));
+        let sender = std::mem::replace(self, ConnectionInfoState::Received);
 
         match sender {
             ConnectionInfoState::Pending(tx) => {
                 let _ = tx.send(info);
             }
-            ConnectionInfoState::Received(_) => unreachable!("ConnectionInfo already sent"),
-        }
-    }
-
-    #[allow(dead_code)]
-    fn get(&self) -> Option<&ConnectionInfo> {
-        match self {
-            ConnectionInfoState::Pending(_) => None,
-            ConnectionInfoState::Received(info) => Some(info),
+            ConnectionInfoState::Received => unreachable!("ConnectionInfo already sent"),
         }
     }
 }
 
 #[derive(Debug)]
-pub struct TlsStream {
-    state: TlsState,
+pub struct TlsStream<IO> {
+    state: TlsState<IO>,
     info: ConnectionInfoState,
     pub(crate) rx: self::info::TlsConnectionInfoReciever,
 }
 
-impl TlsStream {
-    pub fn local_addr(&self) -> &SocketAddr {
-        self.rx.local_addr()
-    }
-
-    pub fn remote_addr(&self) -> &SocketAddr {
-        self.rx.remote_addr()
-    }
-
+impl<IO> TlsStream<IO>
+where
+    IO: AsyncRead + AsyncWrite + Unpin,
+{
     fn handshake<F, R>(&mut self, cx: &mut Context, action: F) -> Poll<io::Result<R>>
     where
-        F: FnOnce(
-            &mut tokio_rustls::server::TlsStream<TcpStream>,
-            &mut Context,
-        ) -> Poll<io::Result<R>>,
+        F: FnOnce(&mut tokio_rustls::server::TlsStream<IO>, &mut Context) -> Poll<io::Result<R>>,
     {
         match self.state {
             TlsState::Handshake(ref mut accept) => match ready!(Pin::new(accept).poll(cx)) {
                 Ok(mut stream) => {
                     // Take some action here when the handshake happens
 
-                    let info = crate::info::ConnectionInfo::Tcp(TLSConnectionInfo::from_stream(
-                        &stream,
-                        self.rx.remote_addr().clone(),
-                    ));
+                    let (_, server_info) = stream.get_ref();
+                    let sni = server_info.server_name().map(|s| s.to_string());
+                    let info = TLSConnectionInfo::new(sni);
                     self.info.send(info.clone());
 
-                    match &info {
-                        ConnectionInfo::Tcp(tcp) => {
-                            tracing::trace!(remote=?tcp.remote_addr, host=%tcp.tls.as_ref().and_then(|tls| tls.sni.as_deref()).unwrap_or("-"), "TLS Handshake complete");
+                    if let Some(local) = self.rx.local_addr() {
+                        if let Some(remote) = self.rx.remote_addr() {
+                            let host = info.sni.as_deref().unwrap_or("-");
+                            tracing::trace!(%local, %remote, %host,  "TLS Handshake complete");
                         }
-                        _ => unreachable!("TLS Handshake on non-TCP connection"),
                     }
-
                     // Back to processing the stream
                     let result = action(&mut stream, cx);
                     self.state = TlsState::Streaming(stream);
@@ -126,28 +107,33 @@ impl TlsStream {
     }
 }
 
-impl TlsStream {
-    fn new(accept: Accept<TcpStream>, remote_addr: SocketAddr) -> Self {
+impl<IO> TlsStream<IO>
+where
+    IO: Connection,
+{
+    pub(crate) fn new(accept: Accept<IO>) -> Self {
         let (tx, rx) = tokio::sync::oneshot::channel();
 
         // We don't expect these to panic because we assume that the handshake has not finished when
         // this implementation is called. As long as no-one manually polls the future and then
         // does this after the future has returned ready, we should be okay.
-        let local_addr = accept
+        let info: ConnectionInfo = accept
             .get_ref()
-            .and_then(|stream| stream.local_addr().ok())
-            .expect("TLS handshake is not yet completed")
-            .into();
+            .map(|stream| stream.info())
+            .expect("TLS handshake should have access to underlying IO");
 
         Self {
             state: TlsState::Handshake(accept),
             info: ConnectionInfoState::new(tx),
-            rx: self::info::TlsConnectionInfoReciever::new(rx, remote_addr, local_addr),
+            rx: self::info::TlsConnectionInfoReciever::new(rx, info),
         }
     }
 }
 
-impl AsyncRead for TlsStream {
+impl<IO> AsyncRead for TlsStream<IO>
+where
+    IO: AsyncRead + AsyncWrite + Unpin,
+{
     fn poll_read(
         self: Pin<&mut Self>,
         cx: &mut Context,
@@ -158,7 +144,10 @@ impl AsyncRead for TlsStream {
     }
 }
 
-impl AsyncWrite for TlsStream {
+impl<IO> AsyncWrite for TlsStream<IO>
+where
+    IO: AsyncRead + AsyncWrite + Unpin,
+{
     fn poll_write(
         self: Pin<&mut Self>,
         cx: &mut Context<'_>,


### PR DESCRIPTION
Allows Braid types to take advantage of TLS on any transport.